### PR TITLE
Convert from Angular 4.2  to Angular 5

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,24 +13,26 @@
     },
     "private": true,
     "dependencies": {
-        "@angular/animations": "^4.2.4",
-        "@angular/common": "^4.2.4",
-        "@angular/compiler": "^4.2.4",
-        "@angular/core": "^4.2.4",
-        "@angular/forms": "^4.2.4",
-        "@angular/http": "^4.2.4",
-        "@angular/platform-browser": "^4.2.4",
-        "@angular/platform-browser-dynamic": "^4.2.4",
-        "@angular/router": "^4.2.4",
-        "core-js": "^2.4.1",
-        "rxjs": "^5.4.2",
-        "zone.js": "^0.8.14",
+        "@angular/animations": "^5.0.0",
+        "@angular/common": "^5.0.0",
+        "@angular/compiler": "^5.0.0",
+        "@angular/core": "^5.0.0",
+        "@angular/forms": "^5.0.0",
+        "@angular/http": "^5.0.0",
+        "@angular/platform-browser": "^5.0.0",
+        "@angular/platform-browser-dynamic": "^5.0.0",
+        "@angular/platform-server": "^5.0.0",
+        "@angular/router": "^5.0.0",
+        "@types/core-js": "^0.9.46",
         "bootstrap": "^4.0.0-beta",
-        "ngx-bootstrap": "^1.9.3"
+        "core-js": "^2.4.1",
+        "ngx-bootstrap": "^1.9.3",
+        "rxjs": "^5.5.2",
+        "zone.js": "^0.8.14"
     },
     "devDependencies": {
         "@angular/cli": "1.3.2",
-        "@angular/compiler-cli": "^4.2.4",
+        "@angular/compiler-cli": "^5.0.0",
         "@angular/language-service": "^4.2.4",
         "@types/jasmine": "~2.5.53",
         "@types/jasminewd2": "~2.0.2",
@@ -47,6 +49,6 @@
         "protractor": "~5.1.2",
         "ts-node": "~3.2.0",
         "tslint": "~5.3.2",
-        "typescript": "~2.3.3"
+        "typescript": "2.4.2"
     }
 }

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {HttpModule, JsonpModule} from '@angular/http';
+import {HttpClientModule} from '@angular/common/http';
 
 import {AppComponent} from './app.component';
 import {NavbarComponent} from './navbar/navbar.component';
@@ -15,8 +15,7 @@ import {APP_BASE_HREF} from "@angular/common";
 @NgModule({
     imports: [
         BrowserModule,
-        HttpModule,
-        JsonpModule,
+        HttpClientModule,
         Routing,
         FormsModule,
     ],

--- a/client/src/app/users/user-list.service.ts
+++ b/client/src/app/users/user-list.service.ts
@@ -1,8 +1,7 @@
 import {Injectable} from '@angular/core';
-import {Http} from '@angular/http';
+import {HttpClient} from '@angular/common/http';
 
 import {Observable} from "rxjs";
-import "rxjs/add/operator/map";
 
 import {User} from './user';
 import {environment} from "../../environments/environment";
@@ -11,15 +10,20 @@ import {environment} from "../../environments/environment";
 export class UserListService {
     private userUrl: string = environment.API_URL + "users";
 
-    constructor(private http: Http) {
+    constructor(private httpClient: HttpClient) {
     }
 
     getUsers(): Observable<User[]> {
-        let observable: Observable<any> = this.http.request(this.userUrl);
+        // return null;
+        /*
+        let observable: Observable<any> = this.httpClient.get(this.userUrl);
         return observable.map(res => res.json());
+        */
+        return this.httpClient.get<User[]>(this.userUrl);
     }
 
     getUserById(id: string): Observable<User> {
-        return this.http.request(this.userUrl + "/" + id).map(res => res.json());
+        // return null;
+        return this.httpClient.get<User>(this.userUrl + "/" + id);
     }
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,5 +15,8 @@
             "es2017",
             "dom"
         ]
+    },
+    "angularCompilerOptions": {
+        "preserveWhitespaces": false
     }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10,9 +10,9 @@
     source-map "^0.5.6"
     typescript "^2.3.3"
 
-"@angular/animations@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.4.1.tgz#578d8951a273ee95936ab7f6cd933ff019ce0ffe"
+"@angular/animations@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-5.2.4.tgz#c5ec749d84a0434733a28a82c6cb6a4e15246201"
   dependencies:
     tslib "^1.7.1"
 
@@ -85,41 +85,42 @@
   optionalDependencies:
     node-sass "^4.3.0"
 
-"@angular/common@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.4.1.tgz#d1aea2ccebddd2dfaf7137f55760d45638ada24a"
+"@angular/common@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.2.4.tgz#a0ee6ef65f731196d3037bce515f7bbec90740d2"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/compiler-cli@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.4.1.tgz#17b3be903efe1ed3bb2b1e29140634b500fdb265"
+"@angular/compiler-cli@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-5.2.4.tgz#6d236f8433abe6752441e20884e599e8aa13c567"
   dependencies:
-    "@angular/tsc-wrapped" "4.3.6"
+    chokidar "^1.4.2"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
+    tsickle "^0.26.0"
 
-"@angular/compiler@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.4.1.tgz#ece6a333f8e57e819679f2a4034f807564b9cc40"
+"@angular/compiler@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.2.4.tgz#f653176bf6c4e253b2c445a1e50941ffba009fb2"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/core@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.4.1.tgz#a3c5b80452448535253d2eab17b60601d83cc012"
+"@angular/core@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.2.4.tgz#44a59bcea87b3aac9ce8ff2ff674fe9cb60e2041"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/forms@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-4.4.1.tgz#2a3644a3f84b96aad240ac6caa74d52bf3ada24a"
+"@angular/forms@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-5.2.4.tgz#a731087e147ca61f5051cbe22597a24d937c4852"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/http@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.4.1.tgz#9265d1802673aa5f73ac125f98fce7af8b5fa72c"
+"@angular/http@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-5.2.4.tgz#da2764875196c3a2c8412457714057e56a6545e2"
   dependencies:
     tslib "^1.7.1"
 
@@ -127,29 +128,31 @@
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-4.4.1.tgz#f44af998e84ff55653642fd7d7fe795a592074ec"
 
-"@angular/platform-browser-dynamic@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.4.1.tgz#951dd7fdb3f5a0e45bc4bf93a2a7e051def24eaf"
+"@angular/platform-browser-dynamic@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.4.tgz#708457c9aafb1b812187c95d10365685521314d4"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/platform-browser@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.4.1.tgz#ce576401976f71d45a23c9a61ac05cef90a70f00"
+"@angular/platform-browser@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.2.4.tgz#dcb2dc6083774dcf2e17c9e9d0653d87057bf732"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/router@^4.2.4":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-4.4.1.tgz#d2c933c84a8f5077792e77787561ee1e7a4a1a14"
+"@angular/platform-server@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-5.2.4.tgz#9ee3313ba4a1c09528206d6de74be60be9bdd0ad"
+  dependencies:
+    domino "^1.0.29"
+    tslib "^1.7.1"
+    xhr2 "^0.1.4"
+
+"@angular/router@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-5.2.4.tgz#21b81958aaf8335454a55ba28ea37166edbcb042"
   dependencies:
     tslib "^1.7.1"
-
-"@angular/tsc-wrapped@4.3.6":
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.3.6.tgz#1aa66e0ab2c4799a4ad14b675e13953aa5fcd436"
-  dependencies:
-    tsickle "^0.21.0"
 
 "@ngtools/json-schema@1.1.0":
   version "1.1.0"
@@ -162,6 +165,10 @@
     loader-utils "^1.0.2"
     magic-string "^0.22.3"
     source-map "^0.5.6"
+
+"@types/core-js@^0.9.46":
+  version "0.9.46"
+  resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"
 
 "@types/jasmine@*":
   version "2.6.0"
@@ -838,7 +845,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chokidar@^1.4.1, chokidar@^1.6.0, chokidar@^1.7.0:
+chokidar@^1.4.1, chokidar@^1.4.2, chokidar@^1.6.0, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1497,6 +1504,10 @@ domhandler@2.1:
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
   dependencies:
     domelementtype "1"
+
+domino@^1.0.29:
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-1.0.30.tgz#54a4154ecae968616680f8feba3cedff355c71f4"
 
 domutils@1.1:
   version "1.1.6"
@@ -4582,6 +4593,12 @@ rxjs@^5.4.2:
   dependencies:
     symbol-observable "^1.0.1"
 
+rxjs@^5.5.2:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -5107,6 +5124,10 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 symbol-observable@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -5253,9 +5274,9 @@ tsconfig@^6.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tsickle@^0.21.0:
-  version "0.21.6"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.21.6.tgz#53b01b979c5c13fdb13afb3fb958177e5991588d"
+tsickle@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.26.0.tgz#40b30a2dd6abcb33b182e37596674bd1cfe4039c"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
@@ -5307,17 +5328,13 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-"typescript@>=2.0.0 <2.5.0":
+typescript@2.4.2, "typescript@>=2.0.0 <2.5.0":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 typescript@^2.3.3:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
-
-typescript@~2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
 uglify-js@3.1.x:
   version "3.1.0"
@@ -5700,6 +5717,10 @@ ws@^1.0.1:
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+
+xhr2@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.4.tgz#7f87658847716db5026323812f818cadab387a5f"
 
 xml-char-classes@^1.0.0:
   version "1.0.0"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,2 @@
 build
+!/src/libs/3601-lab3-todos.jar


### PR DESCRIPTION
I think this gets us converted to Angular 5. I followed the instructions in [this conversion guide](https://angular-update-guide.firebaseapp.com) and that seemed to have worked pretty well. Our project didn't use a lot of the "super fancy" stuff that might have made it more difficult.

The one place where I had to change "content" was in `UserListService`, where the uses of `Http` had to be changed to `HttpClient`, which also changed how calls to the server were made.

It would be great if someone else could try this out (preferably in the lab) to make sure it still works for them and there's not something Nic-specific going on here. The `runClientTests` task should pass (it does for me), but its coverage isn't great. 

Currently, the e2e tests don't pass for me. I think this is related to the problem of using `id` of `class` on users in the HTML and not getting unique `id`s as a result. This means that when the e2e tests try to identify specific users in the HTML that fails.

If it works for you in the lab, then feel free to merge it in. Otherwise I'll probably merge it in tomorrow (Sunday) afternoon so we can move this forward before lab on Tuesday.