### PR TITLE
Fix 'More than one element' warning in e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: java
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -6,5 +8,12 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+addons:
+    chrome: stable
+before_script:
+    - "sudo chown root /opt/google/chrome/chrome-sandbox"
+    - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
+
 jdk:
   - oraclejdk8

--- a/client/e2e/user-list.e2e-spec.ts
+++ b/client/e2e/user-list.e2e-spec.ts
@@ -37,10 +37,10 @@ describe('angular-spark-lab', () => {
 
     it('should click on the age 27 times and return 3 elements then ', () => {
         page.navigateTo();
-        page.getUserByAge();
-        for (let i = 0; i < 27; i++) {
+        page.getUserByAge(27);
+        /*for (let i = 0; i < 27; i++) {
             page.selectUpKey();
-        }
+        }*/
 
         expect(page.getFirstUser()).toEqual("Stokes Clayton is 27 years old");
 

--- a/client/e2e/user-list.e2e-spec.ts
+++ b/client/e2e/user-list.e2e-spec.ts
@@ -38,9 +38,6 @@ describe('angular-spark-lab', () => {
     it('should click on the age 27 times and return 3 elements then ', () => {
         page.navigateTo();
         page.getUserByAge(27);
-        /*for (let i = 0; i < 27; i++) {
-            page.selectUpKey();
-        }*/
 
         expect(page.getFirstUser()).toEqual("Stokes Clayton is 27 years old");
 

--- a/client/e2e/user-list.e2e-spec.ts
+++ b/client/e2e/user-list.e2e-spec.ts
@@ -35,7 +35,7 @@ describe('angular-spark-lab', () => {
         expect(page.getFirstUser()).toEqual("Lynn Ferguson is 25 years old");
     });
 
-    it('should click on the age 27 times and return 3 elements then ', () => {
+    it('should type 27 into the age field and return 3 elements ', () => {
         page.navigateTo();
         page.getUserByAge(27);
 

--- a/client/e2e/user-list.e2e-spec.ts
+++ b/client/e2e/user-list.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('angular-spark-lab', () => {
         expect(page.getUserTitle()).toEqual('User Name');
     });
 
-    it('should type something in filer name box and check that it returned correct element', () => {
+    it('should type something in filter name box and check that it returned correct element', () => {
         page.navigateTo();
         page.typeAName("Lynn");
         expect(page.getFirstUser()).toEqual("Lynn Ferguson is 25 years old");

--- a/client/e2e/user-list.po.ts
+++ b/client/e2e/user-list.po.ts
@@ -43,9 +43,8 @@ export class UserPage {
     }
 
     getFirstUser() {
-        let user = element(by.className('users')).getText();
+        let user = element.all(by.className('users')).first().getText();
         this.highlightElement(by.className('users'));
-
         return user;
     }
 }

--- a/client/e2e/user-list.po.ts
+++ b/client/e2e/user-list.po.ts
@@ -27,7 +27,7 @@ export class UserPage {
     }
 
     typeAName(name: string) {
-        let input = element(by.tagName('input'));
+        let input = element(by.className('name-input'));
         input.click();
         input.sendKeys(name);
     }

--- a/client/e2e/user-list.po.ts
+++ b/client/e2e/user-list.po.ts
@@ -36,15 +36,15 @@ export class UserPage {
         browser.actions().sendKeys(Key.ARROW_UP).perform();
     }
 
-    getUserByAge() {
-        let input = element(by.tagName('input'));
+    getUserByAge(age: number) {
+        let input = element(by.className('age-input'));
         input.click();
-        input.sendKeys(Key.TAB);
+        input.sendKeys(age);
     }
 
     getFirstUser() {
-        let user = element(by.className('user')).getText();
-        this.highlightElement(by.className('user'));
+        let user = element(by.className('users')).getText();
+        this.highlightElement(by.className('users'));
 
         return user;
     }

--- a/client/e2e/user-list.po.ts
+++ b/client/e2e/user-list.po.ts
@@ -43,8 +43,8 @@ export class UserPage {
     }
 
     getFirstUser() {
-        let user = element(by.id('users')).getText();
-        this.highlightElement(by.id('users'));
+        let user = element(by.className('user')).getText();
+        this.highlightElement(by.className('user'));
 
         return user;
     }

--- a/client/e2e/user-list.po.ts
+++ b/client/e2e/user-list.po.ts
@@ -44,7 +44,6 @@ export class UserPage {
 
     getFirstUser() {
         let user = element.all(by.className('users')).first().getText();
-        this.highlightElement(by.className('users'));
         return user;
     }
 }

--- a/client/src/app/users/user-list.component.html
+++ b/client/src/app/users/user-list.component.html
@@ -12,7 +12,7 @@
 </ul>
 
 <ul class="list-group" *ngIf="users; else usersError">
-    <li id="users" *ngFor="let user of this.filterUsers(userName, userAge)" class="list-group-item">
+    <li *ngFor="let user of this.filterUsers(userName, userAge)" class="list-group-item" class="user">
         {{ user.name }} is {{ user.age }} years old
     </li>
 </ul>

--- a/client/src/app/users/user-list.component.html
+++ b/client/src/app/users/user-list.component.html
@@ -4,15 +4,15 @@
         <!-- The names userName and userAge, different from searchName and searchAge, are being
         used here only to illustrate that these inputs are not necessarily explicitly referencable from within
         the typescript. Unless made to do so by defining a userName variable within this component's typescript file-->
-        <input #input type="text" placeholder="Filter by name" (input)="userName = $event.target.value">
-        <input #input type="number" placeholder="Filter by age" (input)="userAge = $event.target.value">
+        <input #input type="text" placeholder="Filter by name" (input)="userName = $event.target.value" class="name-input">
+        <input #input type="number" placeholder="Filter by age" (input)="userAge = $event.target.value" class="age-input">
 
     </li>
     <li id="title" class="list-group-item list-group-item-info">User Name</li>
 </ul>
 
 <ul class="list-group" *ngIf="users; else usersError">
-    <li *ngFor="let user of this.filterUsers(userName, userAge)" class="list-group-item" class="user">
+    <li *ngFor="let user of this.filterUsers(userName, userAge)" class="list-group-item" class="users">
         {{ user.name }} is {{ user.age }} years old
     </li>
 </ul>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1040,14 +1040,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
 connect-history-api-fallback@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz#e51d17f8f0ef0db90a64fdb47de3051556e9f169"
@@ -1679,10 +1671,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise@~4.0.3:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
-
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -1891,15 +1879,6 @@ extract-text-webpack-plugin@3.0.0:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
-extract-zip@~1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
-  dependencies:
-    concat-stream "1.6.0"
-    debug "2.2.0"
-    mkdirp "0.5.0"
-    yauzl "2.4.1"
-
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -1923,12 +1902,6 @@ faye-websocket@~0.11.0:
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
   dependencies:
     websocket-driver ">=0.5.1"
-
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  dependencies:
-    pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2077,14 +2050,6 @@ fs-extra@^4.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2222,7 +2187,7 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2312,13 +2277,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
-
-hasha@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/hasha/-/hasha-2.2.0.tgz#78d7cbfc1e6d66303fe79837365984517b2f6ee1"
-  dependencies:
-    is-stream "^1.0.1"
-    pinkie-promise "^2.0.0"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -2731,7 +2689,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3046,10 +3004,6 @@ karma@~1.7.0:
     tmp "0.0.31"
     useragent "^2.1.12"
 
-kew@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
-
 kind-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
@@ -3067,12 +3021,6 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 lazy-cache@^0.2.3:
   version "0.2.7"
@@ -3395,12 +3343,6 @@ mixin-object@^2.0.1:
   dependencies:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
-
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -3884,27 +3826,9 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-
-phantomjs-prebuilt@^2.1.14:
-  version "2.1.15"
-  resolved "https://registry.yarnpkg.com/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz#20f86e82d3349c505917527745b7a411e08b3903"
-  dependencies:
-    es6-promise "~4.0.3"
-    extract-zip "~1.6.5"
-    fs-extra "~1.0.0"
-    hasha "~2.2.0"
-    kew "~0.7.0"
-    progress "~1.1.8"
-    request "~2.81.0"
-    request-progress "~2.0.1"
-    which "~1.2.10"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -4245,10 +4169,6 @@ process@^0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-progress@~1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -4433,7 +4353,7 @@ readable-stream@1.0, readable-stream@~1.0.2:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6, readable-stream@^2.2.9:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -4547,13 +4467,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request-progress@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-2.0.1.tgz#5d36bb57961c673aa5b788dbc8141fdf23b44e08"
-  dependencies:
-    throttleit "^1.0.0"
-
-request@2, request@^2.72.0, request@^2.78.0, request@^2.79.0, request@^2.81.0, request@~2.81.0:
+request@2, request@^2.72.0, request@^2.78.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5247,10 +5161,6 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-throttleit@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
-
 through@X.X.X, through@^2.3.6, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -5396,10 +5306,6 @@ type-is@~1.6.15:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.15"
-
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 "typescript@>=2.0.0 <2.5.0":
   version "2.4.2"
@@ -5748,12 +5654,6 @@ which@1, which@^1.2.1, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@~1.2.10:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
-  dependencies:
-    isexe "^2.0.0"
-
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
@@ -5923,12 +5823,6 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  dependencies:
-    fd-slicer "~1.0.1"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
I fixed the user list example to use classes instead of IDs where necessary and rewrote the e2e tests so that they no longer give the 'more than one element' warning repeatedly throughout the process.

Closes #42