### PR TITLE
Fix all the TSLint warnings

### DIFF
--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -2,10 +2,10 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {DebugElement} from '@angular/core';
 
-import {AppModule} from "./app.module";
+import {AppModule} from './app.module';
 import {AppComponent} from './app.component';
-import {CustomModule} from "./custom.module";
-import {MATERIAL_COMPATIBILITY_MODE} from "@angular/material";
+import {CustomModule} from './custom.module';
+import {MATERIAL_COMPATIBILITY_MODE} from '@angular/material';
 
 describe('AppComponent', () => {
     let appInstance: AppComponent;
@@ -37,7 +37,7 @@ describe('AppComponent', () => {
 
     it('should render title in the navbar', () => {
         appFixture.detectChanges();
-        let navbar: HTMLElement = debugElement.query(By.css('td-layout-nav')).nativeElement;
+        const navbar: HTMLElement = debugElement.query(By.css('td-layout-nav')).nativeElement;
         expect(navbar.textContent).toContain('menu');
     });
 });

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -9,10 +9,10 @@ import {HomeComponent} from './home/home.component';
 import {UserListComponent} from './users/user-list.component';
 import {UserListService} from './users/user-list.service';
 import {Routing} from './app.routes';
-import {APP_BASE_HREF} from "@angular/common";
+import {APP_BASE_HREF} from '@angular/common';
 
-import {CustomModule} from "./custom.module";
-import {UserComponent} from "./users/user.component";
+import {CustomModule} from './custom.module';
+import {UserComponent} from './users/user.component';
 
 
 @NgModule({

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -2,7 +2,7 @@
 import {ModuleWithProviders} from '@angular/core';
 import {Routes, RouterModule} from '@angular/router';
 import {HomeComponent} from './home/home.component';
-import {UserListComponent} from "./users/user-list.component";
+import {UserListComponent} from './users/user-list.component';
 
 // Route Configuration
 export const routes: Routes = [

--- a/client/src/app/custom.module.ts
+++ b/client/src/app/custom.module.ts
@@ -11,7 +11,7 @@ import {
 import { FlexLayoutModule, } from '@angular/flex-layout';
 
 import { FormsModule } from '@angular/forms';
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 const FLEX_LAYOUT_MODULES: any[] = [
     FlexLayoutModule,

--- a/client/src/app/home/home.component.spec.ts
+++ b/client/src/app/home/home.component.spec.ts
@@ -1,9 +1,9 @@
-import {TestBed, ComponentFixture} from "@angular/core/testing";
-import {HomeComponent} from "./home.component";
-import {DebugElement} from "@angular/core";
-import {By} from "@angular/platform-browser";
-import {CustomModule} from "../custom.module";
-import {MATERIAL_COMPATIBILITY_MODE} from "@angular/material";
+import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {HomeComponent} from './home.component';
+import {DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {CustomModule} from '../custom.module';
+import {MATERIAL_COMPATIBILITY_MODE} from '@angular/material';
 
 describe('Home', () => {
 
@@ -28,7 +28,7 @@ describe('Home', () => {
         el = de.nativeElement;
     });
 
-    it("displays a greeting", () => {
+    it('displays a greeting', () => {
         fixture.detectChanges();
         expect(el.textContent).toContain(component.text);
     });

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -7,6 +7,6 @@ export class HomeComponent {
     public text: string;
 
     constructor() {
-        this.text = "Angular Spark lab";
+        this.text = 'Angular Spark lab';
     }
 }

--- a/client/src/app/users/user-list.component.spec.ts
+++ b/client/src/app/users/user-list.component.spec.ts
@@ -1,13 +1,18 @@
-import {ComponentFixture, TestBed, async} from "@angular/core/testing";
-import {User} from "./user";
-import {UserListComponent} from "./user-list.component";
-import {UserListService} from "./user-list.service";
-import {Observable} from "rxjs";
-import {FormsModule} from "@angular/forms";
-import {CustomModule} from "../custom.module";
-import {MATERIAL_COMPATIBILITY_MODE} from "@angular/material";
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {Observable} from 'rxjs/Observable';
+import {FormsModule} from '@angular/forms';
+import {MATERIAL_COMPATIBILITY_MODE} from '@angular/material';
 
-describe("User list", () => {
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/do';
+
+import {CustomModule} from '../custom.module';
+
+import {User} from './user';
+import {UserListComponent} from './user-list.component';
+import {UserListService} from './user-list.service';
+
+describe('User list', () => {
 
     let userList: UserListComponent;
     let fixture: ComponentFixture<UserListComponent>;
@@ -21,25 +26,25 @@ describe("User list", () => {
         userListServiceStub = {
             getUsers: () => Observable.of([
                 {
-                    id: "chris_id",
-                    name: "Chris",
+                    id: 'chris_id',
+                    name: 'Chris',
                     age: 25,
-                    company: "UMM",
-                    email: "chris@this.that"
+                    company: 'UMM',
+                    email: 'chris@this.that'
                 },
                 {
-                    id: "pat_id",
-                    name: "Pat",
+                    id: 'pat_id',
+                    name: 'Pat',
                     age: 37,
-                    company: "IBM",
-                    email: "pat@something.com"
+                    company: 'IBM',
+                    email: 'pat@something.com'
                 },
                 {
-                    id: "jamie_id",
-                    name: "Jamie",
+                    id: 'jamie_id',
+                    name: 'Jamie',
                     age: 37,
-                    company: "Frogs, Inc.",
-                    email: "jamie@frogs.com"
+                    company: 'Frogs, Inc.',
+                    email: 'jamie@frogs.com'
                 }
             ])
         };
@@ -52,7 +57,7 @@ describe("User list", () => {
             providers: [{provide: UserListService, useValue: userListServiceStub},
             {provide: MATERIAL_COMPATIBILITY_MODE, useValue: true}]
 
-        })
+        });
     });
 
     beforeEach(async(() => {
@@ -63,62 +68,53 @@ describe("User list", () => {
         });
     }));
 
-    it("contains all the users", () => {
+    it('contains all the users', () => {
         expect(userList.users.length).toBe(3);
     });
 
-    it("contains a user named 'Chris'", () => {
-        expect(userList.users.some((user: User) => user.name === "Chris")).toBe(true);
+    it('contains a user named \'Chris\'', () => {
+        expect(userList.users.some((user: User) => user.name === 'Chris')).toBe(true);
     });
 
-    it("contain a user named 'Jamie'", () => {
-        expect(userList.users.some((user: User) => user.name === "Jamie")).toBe(true);
+    it('contain a user named \'Jamie\'', () => {
+        expect(userList.users.some((user: User) => user.name === 'Jamie')).toBe(true);
     });
 
-    it("doesn't contain a user named 'Santa'", () => {
-        expect(userList.users.some((user: User) => user.name === "Santa")).toBe(false);
+    it('doesn\'t contain a user named \'Santa\'', () => {
+        expect(userList.users.some((user: User) => user.name === 'Santa')).toBe(false);
     });
 
-    it("has two users that are 37 years old", () => {
+    it('has two users that are 37 years old', () => {
         expect(userList.users.filter((user: User) => user.age === 37).length).toBe(2);
     });
-    it("user list filters by name", () => {
+    it('user list filters by name', () => {
         expect(userList.filteredUsers.length).toBe(3);
-        userList.userName = "a";
-        let a : Observable<User[]> = userList.refreshUsers();
+        userList.userName = 'a';
+        const a: Observable<User[]> = userList.refreshUsers();
         a.do(x => Observable.of(x))
-            .subscribe(x =>
-            {
-                expect(userList.filteredUsers.length).toBe(2);
-            });
+            .subscribe(x => expect(userList.filteredUsers.length).toBe(2));
     });
 
-    it("user list filters by age", () => {
+    it('user list filters by age', () => {
         expect(userList.filteredUsers.length).toBe(3);
         userList.userAge = 37;
-        let a : Observable<User[]> = userList.refreshUsers();
+        const a: Observable<User[]> = userList.refreshUsers();
         a.do(x => Observable.of(x))
-            .subscribe(x =>
-            {
-                expect(userList.filteredUsers.length).toBe(2);
-            });
+            .subscribe(x => expect(userList.filteredUsers.length).toBe(2));
     });
 
-    it("user list filters by name and age", () => {
+    it('user list filters by name and age', () => {
         expect(userList.filteredUsers.length).toBe(3);
         userList.userAge = 37;
-        userList.userName = "i";
-        let a : Observable<User[]> = userList.refreshUsers();
+        userList.userName = 'i';
+        const a: Observable<User[]> = userList.refreshUsers();
         a.do(x => Observable.of(x))
-            .subscribe(x =>
-            {
-                expect(userList.filteredUsers.length).toBe(1);
-            });
+            .subscribe(x => expect(userList.filteredUsers.length).toBe(1));
     });
 
 });
 
-describe("Misbehaving User List", () => {
+describe('Misbehaving User List', () => {
     let userList: UserListComponent;
     let fixture: ComponentFixture<UserListComponent>;
 
@@ -130,7 +126,7 @@ describe("Misbehaving User List", () => {
         // stub UserService for test purposes
         userListServiceStub = {
             getUsers: () => Observable.create(observer => {
-                observer.error("Error-prone observable");
+                observer.error('Error-prone observable');
             })
         };
 
@@ -139,7 +135,7 @@ describe("Misbehaving User List", () => {
             declarations: [UserListComponent],
             providers: [{provide: UserListService, useValue: userListServiceStub},
                 {provide: MATERIAL_COMPATIBILITY_MODE, useValue: true}]
-        })
+        });
     });
 
     beforeEach(async(() => {
@@ -150,7 +146,7 @@ describe("Misbehaving User List", () => {
         });
     }));
 
-    it("generates an error if we don't set up a UserListService", () => {
+    it('generates an error if we don\'t set up a UserListService', () => {
         // Since the observer throws an error, we don't expect users to be defined.
         expect(userList.users).toBeUndefined();
     });

--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -1,29 +1,29 @@
 import {Component, OnInit} from '@angular/core';
-import {UserListService} from "./user-list.service";
-import {User} from "./user";
-import {Observable} from "rxjs";
+import {UserListService} from './user-list.service';
+import {User} from './user';
+import {Observable} from 'rxjs/Observable';
 
 @Component({
-    selector: 'user-list-component',
+    selector: 'app-user-list-component',
     templateUrl: 'user-list.component.html',
     styleUrls: ['./user-list.component.css'],
     providers: []
 })
 
 export class UserListComponent implements OnInit {
-    //These are public so that tests can reference them (.spec.ts)
+    // These are public so that tests can reference them (.spec.ts)
     public users: User[];
     public filteredUsers: User[];
 
-    public userName : string;
-    public userAge : number;
+    public userName: string;
+    public userAge: number;
 
 
-    //Inject the UserListService into this component.
-    //That's what happens in the following constructor.
+    // Inject the UserListService into this component.
+    // That's what happens in the following constructor.
     //
-    //We can call upon the service for interacting
-    //with the server.
+    // We can call upon the service for interacting
+    // with the server.
 
     constructor(private userListService: UserListService) {
 
@@ -33,7 +33,7 @@ export class UserListComponent implements OnInit {
 
         this.filteredUsers = this.users;
 
-        //Filter by name
+        // Filter by name
         if (searchName != null) {
             searchName = searchName.toLocaleLowerCase();
 
@@ -42,10 +42,10 @@ export class UserListComponent implements OnInit {
             });
         }
 
-        //Filter by age
+        // Filter by age
         if (searchAge != null) {
-            this.filteredUsers = this.filteredUsers.filter(user => {
-                return !searchAge || user.age == searchAge;
+            this.filteredUsers = this.filteredUsers.filter((user: User) => {
+                return !searchAge || (user.age === Number(searchAge));
             });
         }
 
@@ -57,16 +57,16 @@ export class UserListComponent implements OnInit {
      *
      */
     refreshUsers(): Observable<User[]> {
-        //Get Users returns an Observable, basically a "promise" that
-        //we will get the data from the server.
+        // Get Users returns an Observable, basically a "promise" that
+        // we will get the data from the server.
         //
-        //Subscribe waits until the data is fully downloaded, then
-        //performs an action on it (the first lambda)
+        // Subscribe waits until the data is fully downloaded, then
+        // performs an action on it (the first lambda)
 
-        let users : Observable<User[]> = this.userListService.getUsers();
+        const users: Observable<User[]> = this.userListService.getUsers();
         users.subscribe(
-            users => {
-                this.users = users;
+            returnedUsers => {
+                this.users = returnedUsers;
                 this.filterUsers(this.userName, this.userAge);
             },
             err => {

--- a/client/src/app/users/user-list.service.spec.ts
+++ b/client/src/app/users/user-list.service.spec.ts
@@ -2,32 +2,32 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
-import {User} from "./user";
-import {UserListService} from "./user-list.service";
+import {User} from './user';
+import {UserListService} from './user-list.service';
 
-describe("User list service: ", () => {
+describe('User list service: ', () => {
     // A small collection of test users
     const testUsers: User[] = [
         {
-            id: "chris_id",
-            name: "Chris",
+            id: 'chris_id',
+            name: 'Chris',
             age: 25,
-            company: "UMM",
-            email: "chris@this.that"
+            company: 'UMM',
+            email: 'chris@this.that'
         },
         {
-            id: "pat_id",
-            name: "Pat",
+            id: 'pat_id',
+            name: 'Pat',
             age: 37,
-            company: "IBM",
-            email: "pat@something.com"
+            company: 'IBM',
+            email: 'pat@something.com'
         },
         {
-            id: "jamie_id",
-            name: "Jamie",
+            id: 'jamie_id',
+            name: 'Jamie',
             age: 37,
-            company: "Frogs, Inc.",
-            email: "jamie@frogs.com"
+            company: 'Frogs, Inc.',
+            email: 'jamie@frogs.com'
         }
     ];
     let userListService: UserListService;
@@ -54,7 +54,7 @@ describe("User list service: ", () => {
         httpTestingController.verify();
     });
 
-    it("getUsers() calls api/users", () => {
+    it('getUsers() calls api/users', () => {
         // Assert that the users we get from this call to getUsers()
         // should be our set of test users. Because we're subscribing
         // to the result of getUsers(), this won't actually get
@@ -75,14 +75,14 @@ describe("User list service: ", () => {
         req.flush(testUsers);
     });
 
-    it ("getUserById() calls api/users/id", () => {
+    it ('getUserById() calls api/users/id', () => {
         const targetUser: User = testUsers[1];
         const targetId: string = targetUser.id;
         userListService.getUserById(targetId).subscribe(
             user => expect(user).toBe(targetUser)
         );
 
-        const expectedUrl: string = userListService.userUrl + "/" + targetId;
+        const expectedUrl: string = userListService.userUrl + '/' + targetId;
         const req = httpTestingController.expectOne(expectedUrl);
         expect(req.request.method).toEqual('GET');
         req.flush(targetUser);

--- a/client/src/app/users/user-list.service.ts
+++ b/client/src/app/users/user-list.service.ts
@@ -1,14 +1,14 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 
-import {Observable} from "rxjs";
+import {Observable} from 'rxjs/Observable';
 
 import {User} from './user';
-import {environment} from "../../environments/environment";
+import {environment} from '../../environments/environment';
 
 @Injectable()
 export class UserListService {
-    readonly userUrl: string = environment.API_URL + "users";
+    readonly userUrl: string = environment.API_URL + 'users';
 
     constructor(private httpClient: HttpClient) {
     }
@@ -18,6 +18,6 @@ export class UserListService {
     }
 
     getUserById(id: string): Observable<User> {
-        return this.httpClient.get<User>(this.userUrl + "/" + id);
+        return this.httpClient.get<User>(this.userUrl + '/' + id);
     }
 }

--- a/client/src/app/users/user.component.spec.ts
+++ b/client/src/app/users/user.component.spec.ts
@@ -1,11 +1,11 @@
-import {ComponentFixture, TestBed, async} from "@angular/core/testing";
-import {User} from "./user";
-import {UserComponent} from "./user.component";
-import {UserListService} from "./user-list.service";
-import {Observable} from "rxjs";
-//import { PipeModule } from "../../pipe.module";
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {User} from './user';
+import {UserComponent} from './user.component';
+import {UserListService} from './user-list.service';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
 
-describe("User component", () => {
+describe('User component', () => {
 
     let userComponent: UserComponent;
     let fixture: ComponentFixture<UserComponent>;
@@ -19,34 +19,33 @@ describe("User component", () => {
         userListServiceStub = {
             getUserById: (userId: string) => Observable.of([
                 {
-                    id: "chris_id",
-                    name: "Chris",
+                    id: 'chris_id',
+                    name: 'Chris',
                     age: 25,
-                    company: "UMM",
-                    email: "chris@this.that"
+                    company: 'UMM',
+                    email: 'chris@this.that'
                 },
                 {
-                    id: "pat_id",
-                    name: "Pat",
+                    id: 'pat_id',
+                    name: 'Pat',
                     age: 37,
-                    company: "IBM",
-                    email: "pat@something.com"
+                    company: 'IBM',
+                    email: 'pat@something.com'
                 },
                 {
-                    id: "jamie_id",
-                    name: "Jamie",
+                    id: 'jamie_id',
+                    name: 'Jamie',
                     age: 37,
-                    company: "Frogs, Inc.",
-                    email: "jamie@frogs.com"
+                    company: 'Frogs, Inc.',
+                    email: 'jamie@frogs.com'
                 }
             ].find(user => user.id === userId))
         };
 
         TestBed.configureTestingModule({
-            //imports: [PipeModule],
             declarations: [UserComponent],
             providers: [{provide: UserListService, useValue: userListServiceStub}]
-        })
+        });
     });
 
     beforeEach(async(() => {
@@ -56,15 +55,15 @@ describe("User component", () => {
         });
     }));
 
-    it("can retrieve Pat by ID", () => {
-        userComponent.setId("pat_id");
+    it('can retrieve Pat by ID', () => {
+        userComponent.setId('pat_id');
         expect(userComponent.user).toBeDefined();
-        expect(userComponent.user.name).toBe("Pat");
-        expect(userComponent.user.email).toBe("pat@something.com");
+        expect(userComponent.user.name).toBe('Pat');
+        expect(userComponent.user.email).toBe('pat@something.com');
     });
 
-    it("returns undefined for Santa", () => {
-        userComponent.setId("Santa");
+    it('returns undefined for Santa', () => {
+        userComponent.setId('Santa');
         expect(userComponent.user).not.toBeDefined();
     });
 

--- a/client/src/app/users/user.component.ts
+++ b/client/src/app/users/user.component.ts
@@ -1,9 +1,9 @@
 import {Component, OnInit} from '@angular/core';
-import {UserListService} from "./user-list.service";
-import {User} from "./user";
+import {UserListService} from './user-list.service';
+import {User} from './user';
 
 @Component({
-    selector: 'user-component',
+    selector: 'app-user-component',
     styleUrls: ['./user.component.css'],
     templateUrl: 'user.component.html'
 })

--- a/client/src/app/users/user.ts
+++ b/client/src/app/users/user.ts
@@ -1,7 +1,7 @@
 export interface User {
-    id: string,
-    name: string,
-    age: number,
-    company: string,
-    email: string
+    id: string;
+    name: string;
+    age: number;
+    company: string;
+    email: string;
 }

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -5,5 +5,5 @@
 
 export const environment = {
     production: false,
-    API_URL: "http://localhost:4567/api/"
+    API_URL: 'http://localhost:4567/api/'
 };


### PR DESCRIPTION
I think this closes #33 and #37 as it removes all the TSLint warnings, including the gazillion issues where we'd used double quotes when single quotes are the recommended standard.

This is likely to be a bear when merging, especially if you've made any changes to your `imports`, so be prepared to deal with some conflicts.

There are still a handful of IntelliJ warnings. Some (like spelling "mistakes") we aren't going to fix because they're not actual problems. Some others, though, I don't really understand, and we might want to try to address them if someone can make sense of what's being said.