### PR TITLE
Move user filter to service

### DIFF
--- a/client/src/app/users/user-list.component.html
+++ b/client/src/app/users/user-list.component.html
@@ -5,18 +5,26 @@
       <mat-divider></mat-divider>
       <mat-card-content>
         <mat-form-field>
-          <input matInput id="userName" #input placeholder="Filter by name" (input)="userName = $event.target.value">
+          <input
+            matInput
+            id="userName"
+            placeholder="Filter by name"
+            (input)="updateName($event.target.value)">
         </mat-form-field>
         <mat-form-field>
-          <input matInput id="userAge" #input type="number" placeholder="Filter by age"
-                 (input)="userAge = $event.target.value">
+          <input
+            matInput
+            id="userAge"
+            type="number"
+            placeholder="Filter by age"
+            (input)="updateAge($event.target.value)">
         </mat-form-field>
         <!--<mat-form-field>-->
         <!--<input matInput id="userCompany" #input type="text" placeholder="Search for company" (input)="contentChange($event.target.value)">-->
         <!--</mat-form-field>-->
 
         <mat-accordion *ngIf="users; else usersError">
-          <mat-expansion-panel #elem [id]="user.email" *ngFor="let user of this.filterUsers(userName, userAge)">
+          <mat-expansion-panel #elem [id]="user.email" *ngFor="let user of this.filteredUsers">
             <mat-expansion-panel-header>
 
               <mat-panel-title matTooltip="email: {{user.email}}">{{user.name}}</mat-panel-title>

--- a/client/src/app/users/user-list.component.spec.ts
+++ b/client/src/app/users/user-list.component.spec.ts
@@ -87,31 +87,6 @@ describe('User list', () => {
   it('has two users that are 37 years old', () => {
     expect(userList.users.filter((user: User) => user.age === 37).length).toBe(2);
   });
-  it('user list filters by name', () => {
-    expect(userList.filteredUsers.length).toBe(3);
-    userList.userName = 'a';
-    const a: Observable<User[]> = userList.refreshUsers();
-    a.do(x => Observable.of(x))
-      .subscribe(x => expect(userList.filteredUsers.length).toBe(2));
-  });
-
-  it('user list filters by age', () => {
-    expect(userList.filteredUsers.length).toBe(3);
-    userList.userAge = 37;
-    const a: Observable<User[]> = userList.refreshUsers();
-    a.do(x => Observable.of(x))
-      .subscribe(x => expect(userList.filteredUsers.length).toBe(2));
-  });
-
-  it('user list filters by name and age', () => {
-    expect(userList.filteredUsers.length).toBe(3);
-    userList.userAge = 37;
-    userList.userName = 'i';
-    const a: Observable<User[]> = userList.refreshUsers();
-    a.do(x => Observable.of(x))
-      .subscribe(x => expect(userList.filteredUsers.length).toBe(1));
-  });
-
 });
 
 describe('Misbehaving User List', () => {

--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -51,27 +51,14 @@ export class UserListComponent implements OnInit {
    * Starts an asynchronous operation to update the users list
    *
    */
-  refreshUsers(): Observable<User[]> {
-    // Get Users returns an Observable, basically a "promise" that
-    // we will get the data from the server.
-    //
-    // Subscribe waits until the data is fully downloaded, then
-    // performs an action on it (the first lambda)
-
+  ngOnInit(): void {
     const users: Observable<User[]> = this.userListService.getUsers();
     users.subscribe(
       returnedUsers => {
         this.users = returnedUsers;
-        this.updateFilter();
       },
       err => {
         console.log(err);
       });
-    return users;
-  }
-
-
-  ngOnInit(): void {
-    this.refreshUsers();
   }
 }

--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -29,27 +29,22 @@ export class UserListComponent implements OnInit {
 
   }
 
-  public filterUsers(searchName: string, searchAge: number): User[] {
+  public updateName(newName: string): void {
+    this.userName = newName;
+    this.updateFilter();
+  }
 
-    this.filteredUsers = this.users;
+  public updateAge(newAge: number): void {
+    this.userAge = newAge;
+    this.updateFilter();
+  }
 
-    // Filter by name
-    if (searchName != null) {
-      searchName = searchName.toLocaleLowerCase();
-
-      this.filteredUsers = this.filteredUsers.filter(user => {
-        return !searchName || user.name.toLowerCase().indexOf(searchName) !== -1;
-      });
-    }
-
-    // Filter by age
-    if (searchAge != null) {
-      this.filteredUsers = this.filteredUsers.filter((user: User) => {
-        return !searchAge || (user.age === Number(searchAge));
-      });
-    }
-
-    return this.filteredUsers;
+  public updateFilter() {
+    this.filteredUsers =
+      this.userListService.filterUsers(
+        this.users,
+        this.userName,
+        this.userAge);
   }
 
   /**
@@ -67,7 +62,7 @@ export class UserListComponent implements OnInit {
     users.subscribe(
       returnedUsers => {
         this.users = returnedUsers;
-        this.filterUsers(this.userName, this.userAge);
+        this.updateFilter();
       },
       err => {
         console.log(err);

--- a/client/src/app/users/user-list.service.spec.ts
+++ b/client/src/app/users/user-list.service.spec.ts
@@ -87,4 +87,23 @@ describe('User list service: ', () => {
     expect(req.request.method).toEqual('GET');
     req.flush(targetUser);
   });
+
+  it('filterUsers() filters by name', () => {
+    expect(testUsers.length).toBe(3);
+    let userName = 'a';
+    expect(userListService.filterUsers(testUsers, userName).length).toBe(2);
+  });
+
+  it('filterUsers() filters by age', () => {
+    expect(testUsers.length).toBe(3);
+    let userAge = 37;
+    expect(userListService.filterUsers(testUsers, null, userAge).length).toBe(2);
+  });
+
+  it('filterUsers() filters by name and age', () => {
+    expect(testUsers.length).toBe(3);
+    let userAge = 37;
+    let userName = 'i';
+    expect(userListService.filterUsers(testUsers, userName, userAge).length).toBe(1);
+  });
 });

--- a/client/src/app/users/user-list.service.ts
+++ b/client/src/app/users/user-list.service.ts
@@ -21,7 +21,7 @@ export class UserListService {
     return this.httpClient.get<User>(this.userUrl + '/' + id);
   }
 
-  filterUsers(users: User[], searchName: string, searchAge: number): User[] {
+  filterUsers(users: User[], searchName?: string, searchAge?: number): User[] {
 
     let filteredUsers = users;
 

--- a/client/src/app/users/user-list.service.ts
+++ b/client/src/app/users/user-list.service.ts
@@ -20,4 +20,27 @@ export class UserListService {
   getUserById(id: string): Observable<User> {
     return this.httpClient.get<User>(this.userUrl + '/' + id);
   }
+
+  filterUsers(users: User[], searchName: string, searchAge: number): User[] {
+
+    let filteredUsers = users;
+
+    // Filter by name
+    if (searchName != null) {
+      searchName = searchName.toLowerCase();
+
+      filteredUsers = filteredUsers.filter(user => {
+        return !searchName || user.name.toLowerCase().indexOf(searchName) !== -1;
+      });
+    }
+
+    // Filter by age
+    if (searchAge != null) {
+      filteredUsers = filteredUsers.filter((user: User) => {
+        return !searchAge || (user.age === Number(searchAge));
+      });
+    }
+
+    return filteredUsers;
+  }
 }


### PR DESCRIPTION
This PR includes
- moving the user list filtering logic to the service
- moving the filtering tests from user-list.component to user-list.service
- removing the inefficient *ngFor binding (and related refactoring in user-list.component)