### PR TITLE
Fix the lab

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -5,8 +5,6 @@ plugins {
 }
 
 node {
-  version = '6.11.2'
-  download = true
   workDir = file("${project.projectDir}/node")
   yarnWorkDir = file("${project.projectDir}/yarn")
   nodeModulesDir = file("${project.projectDir}/")

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "@angular/common": "^5.0.0",
     "@angular/compiler": "^5.0.0",
     "@angular/core": "^5.0.0",
-    "@angular/flex-layout": "^2.0.0-beta.10-4905443",
+    "@angular/flex-layout": "2.0.0-beta.12",
     "@angular/forms": "^5.0.0",
     "@angular/http": "^5.0.0",
     "@angular/material": "2.0.0-beta.11",

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "@angular/common": "^5.0.0",
     "@angular/compiler": "^5.0.0",
     "@angular/core": "^5.0.0",
-    "@angular/flex-layout": "^2.0.0-beta.9",
+    "@angular/flex-layout": "^2.0.0-beta.10-4905443",
     "@angular/forms": "^5.0.0",
     "@angular/http": "^5.0.0",
     "@angular/material": "2.0.0-beta.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
We tested it with KK and my account and it seems to work now. The issue was that all the yarn install stuff happened with node 6.x because that's what gradle was set to but it runs `ng` stuff with node 10.x, eg what is local in the lab. Also because of `^` in some versions of stuff in package.json, it tries to get the latest minor version and that causes problems with flex-layout specifically so I locked the version to `2.0.0-beta.12`.