### PR TITLE
Improve `UserProfileComponent` testing

### DIFF
--- a/client/src/app/users/user-list.component.spec.ts
+++ b/client/src/app/users/user-list.component.spec.ts
@@ -96,10 +96,10 @@ describe('Misbehaving User List', () => {
   beforeEach(() => {
     // stub UserService for test purposes
     userServiceStub = {
-      getUsers: () => Observable.create(observer => {
+      getUsers: () => new Observable(observer => {
         observer.error('Error-prone observable');
       }),
-      getUsersFiltered: () => Observable.create(observer => {
+      getUsersFiltered: () => new Observable(observer => {
         observer.error('Error-prone observable');
       })
     };

--- a/client/src/app/users/user-list.component.spec.ts
+++ b/client/src/app/users/user-list.component.spec.ts
@@ -1,27 +1,24 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Observable} from 'rxjs';
-import { of } from 'rxjs';
-import {FormsModule} from '@angular/forms';
-
-
-import {User} from './user';
-import {UserListComponent} from './user-list.component';
-import {UserService} from './user.service';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { MatOptionModule } from '@angular/material/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
-import { MatInputModule } from '@angular/material/input';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatListModule } from '@angular/material/list';
+import { MatCardModule } from '@angular/material/card';
+import { MatOptionModule } from '@angular/material/core';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import {MatRadioModule} from '@angular/material/radio';
-import { MockUserService } from './user.service.mock';
+import { Observable } from 'rxjs';
+import { MockUserService } from '../../testing/user.service.mock';
+import { User } from './user';
 import { UserCardComponent } from './user-card.component';
+import { UserListComponent } from './user-list.component';
+import { UserService } from './user.service';
 
 const COMMON_IMPORTS: any[] = [
   FormsModule,
@@ -51,7 +48,7 @@ describe('User list', () => {
       declarations: [UserListComponent, UserCardComponent],
       // providers:    [ UserService ]  // NO! Don't provide the real service!
       // Provide a test-double instead
-      providers: [{provide: UserService, useValue: new MockUserService()}]
+      providers: [{ provide: UserService, useValue: new MockUserService() }]
     });
   });
 
@@ -109,7 +106,7 @@ describe('Misbehaving User List', () => {
       declarations: [UserListComponent],
       // providers:    [ UserService ]  // NO! Don't provide the real service!
       // Provide a test-double instead
-      providers: [{provide: UserService, useValue: userServiceStub}]
+      providers: [{ provide: UserService, useValue: userServiceStub }]
     });
   });
 

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -1,29 +1,32 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { UserProfileComponent } from './user-profile.component';
-import { RouterTestingModule } from '@angular/router/testing';
-import { UserCardComponent } from './user-card.component';
-import { of, Observable } from 'rxjs';
-import { User } from './user';
-import { UserService } from './user.service';
 import { MatCardModule } from '@angular/material/card';
-import { MockUserService } from './user.service.mock';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRouteStub } from '../../testing/activated-route-stub';
+import { MockUserService } from '../../testing/user.service.mock';
+import { User } from './user';
+import { UserCardComponent } from './user-card.component';
+import { UserProfileComponent } from './user-profile.component';
+import { UserService } from './user.service';
 
 describe('UserProfileComponent', () => {
   let component: UserProfileComponent;
   let fixture: ComponentFixture<UserProfileComponent>;
+  const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub();
 
   beforeEach(async(() => {
-
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
         MatCardModule
       ],
-      declarations: [ UserProfileComponent, UserCardComponent ],
-      providers: [{provide: UserService, useValue: new MockUserService()}]
+      declarations: [UserProfileComponent, UserCardComponent],
+      providers: [
+        { provide: UserService, useValue: new MockUserService() },
+        { provide: ActivatedRoute, useValue: activatedRoute }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -32,7 +32,44 @@ describe('UserProfileComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to a specific user profile', () => {
+    const expectedUser: User = MockUserService.testUsers[0];
+    // Setting this should cause anyone subscribing to the paramMap
+    // to update. Our `UserProfileComponent` subscribes to that, so
+    // it should update right away.
+    activatedRoute.setParamMap({ id: expectedUser._id });
+
+    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
+  });
+
+  it('should navigate to correct user when the id parameter changes', () => {
+    let expectedUser: User = MockUserService.testUsers[0];
+    // Setting this should cause anyone subscribing to the paramMap
+    // to update. Our `UserProfileComponent` subscribes to that, so
+    // it should update right away.
+    activatedRoute.setParamMap({ id: expectedUser._id });
+
+    expect(component.id).toEqual(expectedUser._id);
+
+    // Changing the paramMap should update the displayed user profile.
+    expectedUser = MockUserService.testUsers[1];
+    activatedRoute.setParamMap({ id: expectedUser._id });
+
+    expect(component.id).toEqual(expectedUser._id);
+  });
+
+  it('should have `null` for the user for a bad ID', () => {
+    activatedRoute.setParamMap({ id: 'badID' });
+
+    // If the given ID doesn't map to a user, we expect the service
+    // to return `null`, so we would expect the component's user
+    // to also be `null`.
+    expect(component.id).toEqual('badID');
+    expect(component.user).toBeNull();
   });
 });

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -13,10 +13,15 @@ export class UserProfileComponent implements OnInit {
   constructor(private route: ActivatedRoute, private userService: UserService) { }
 
   user: User;
+  id: string;
 
   ngOnInit(): void {
+    // We subscribe to the parameter map here so we'll be notified whenever
+    // that changes (i.e., when the URL changes) so this component will update
+    // to display the newly requested user.
     this.route.paramMap.subscribe((pmap) => {
-      this.userService.getUserById(pmap.get('id')).subscribe(user => this.user = user);
+      this.id = pmap.get('id');
+      this.userService.getUserById(this.id).subscribe(user => this.user = user);
     });
   }
 

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { UserService } from './user.service';
 import { User } from './user';
+import { UserService } from './user.service';
 
 @Component({
   selector: 'app-user-profile',
@@ -12,12 +12,12 @@ export class UserProfileComponent implements OnInit {
 
   constructor(private route: ActivatedRoute, private userService: UserService) { }
 
-  id: string;
   user: User;
 
   ngOnInit(): void {
-    this.id = this.route.snapshot.paramMap.get('id');
-    this.userService.getUserById(this.id).subscribe(user => this.user = user);
+    this.route.paramMap.subscribe((pmap) => {
+      this.userService.getUserById(pmap.get('id')).subscribe(user => this.user = user);
+    });
   }
 
 }

--- a/client/src/testing/activated-route-stub.ts
+++ b/client/src/testing/activated-route-stub.ts
@@ -1,0 +1,26 @@
+import { convertToParamMap, ParamMap, Params } from '@angular/router';
+import { ReplaySubject } from 'rxjs';
+
+// This code is taken from https://angular.io/guide/testing#activatedroutestub
+
+/**
+ * An ActivateRoute test double with a `paramMap` observable.
+ * Use the `setParamMap()` method to add the next `paramMap` value.
+ */
+export class ActivatedRouteStub {
+  // Use a ReplaySubject to share previous values with subscribers
+  // and pump new values into the `paramMap` observable
+  private subject = new ReplaySubject<ParamMap>();
+
+  constructor(initialParams?: Params) {
+    this.setParamMap(initialParams);
+  }
+
+  /** The mock paramMap observable */
+  readonly paramMap = this.subject.asObservable();
+
+  /** Set the paramMap observables's next value */
+  setParamMap(params?: Params) {
+    this.subject.next(convertToParamMap(params));
+  }
+}

--- a/client/src/testing/user.service.mock.ts
+++ b/client/src/testing/user.service.mock.ts
@@ -1,11 +1,15 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { User, UserRole } from './user';
-import { UserService } from './user.service';
+import { User, UserRole } from '../app/users/user';
+import { UserService } from '../app/users/user.service';
 
+/**
+ * A "mock" version of the `UserService` that can be used to test components
+ * without having to create an actual service.
+ */
 @Injectable()
 export class MockUserService extends UserService {
-  testUsers: User[] = [
+  static testUsers: User[] = [
     {
       _id: 'chris_id',
       name: 'Chris',
@@ -39,13 +43,20 @@ export class MockUserService extends UserService {
     super(null);
   }
 
-
   getUsers(filters: { role?: UserRole, age?: number, company?: string }): Observable<User[]> {
-    return of(this.testUsers); // Just return the test users regardless of what filters are passed in
+    // Just return the test users regardless of what filters are passed in
+    return of(MockUserService.testUsers);
   }
 
   getUserById(id: string): Observable<User> {
-    return of(this.testUsers[0]);
+    // If the specified ID is for the first test user,
+    // return that user, otherwise return `null` so
+    // we can test illegal user requests.
+    if (id === MockUserService.testUsers[0]._id) {
+      return of(MockUserService.testUsers[0]);
+    } else {
+      return of(null);
+    }
   }
 
 }


### PR DESCRIPTION
This uses [some nifty ideas from the Angular docs](https://angular.io/guide/testing#activatedroutestub) to add some nice route-based testing to `UserProfileComponent`. Thanks to @floogulinc for the pointer.

I also cleaned up a bunch of TSLint warnings, etc., while I was there.